### PR TITLE
docs: Update all documentation to fix typos and improve readability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,5 +59,5 @@ Push your branch to your `cxcli` fork and open a pull request against the main b
 
 ## Financial contributions
 
-You can contribute in our Github Sponsors or to any of the contributors directly.
+You can contribute in our GitHub Sponsors or to any of the contributors directly.
 See [this page](https://cxcli.xavidop.me/sponsors) for more details.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 ---
 
-`cxcli` is a tool that helps Dialogflow CX users to test their projects and interact with them in multiple ways.
-It is useful for your day-today taks or if you want to integrate it in your favorite CI.
+`cxcli` is a command-line tool that helps Dialogflow CX users test their agents and interact with them in various ways.
+It is useful for your day-to-day tasks or if you want to integrate it with your favorite CI tool.
 
-This CLI also has text-to-speech and speech-to text capabilities allowing the interaction with Google Cloud Platform APIs.
+This CLI also allows you to interact with the [text-to-speech](/tts) and [speech-to text](/stt) APIs in Google Cloud.
 
 ---
 
@@ -49,7 +49,7 @@ Please refer to our [contributing guidelines](CONTRIBUTING.md) for further infor
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cxcli&style=for-the-badge)](https://artifacthub.io/packages/search?repo=cxcli)
 [![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg?style=for-the-badge)](http://godoc.org/github.com/xavidop/dialogflow-cx-cli)
 [![Powered By: GoReleaser](https://img.shields.io/badge/powered%20by-goreleaser-green.svg?style=for-the-badge)](https://github.com/goreleaser)
-[![Sponsors on Github](https://opencollective.com/cxcli/sponsors/badge.svg?style=for-the-badge)](https://github.com/sponsors/xavidop)
+[![Sponsors on GitHub](https://opencollective.com/cxcli/sponsors/badge.svg?style=for-the-badge)](https://github.com/sponsors/xavidop)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge)](https://conventionalcommits.org)
 [![Go Report Card](https://goreportcard.com/badge/github.com/xavidop/dialogflow-cx-cli)](https://goreportcard.com/report/github.com/xavidop/dialogflow-cx-cli)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fxavidop%2Fdialogflow-cx-cli.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fxavidop%2Fdialogflow-cx-cli?ref=badge_shield)

--- a/cmd/cmdutils/utils.go
+++ b/cmd/cmdutils/utils.go
@@ -15,7 +15,7 @@ func CheckUpdate(output bool) {
 	latestVersion, _ := utils.CheckAvailableUpdate(global.VersionString, output)
 
 	if latestVersion != "" {
-		global.Log.Warnf("A new version is available: %s. Please update the tool using your package manager or downloading the latest release from Github: https://github.com/xavidop/dialogflow-cx-cli/releases/latest", latestVersion)
+		global.Log.Warnf("A new version is available: %s. Please update the tool using your package manager or downloading the latest release from GitHub: https://github.com/xavidop/dialogflow-cx-cli/releases/latest", latestVersion)
 	} else {
 		if output && latestVersion == "" {
 			global.Log.Infof("You have installed the latest version!")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,13 +24,13 @@ var rootCmd = &cobra.Command{
 	Use:   "cxcli",
 	Short: "Dialogflow CX CLI",
 	Long: `Welcome to cxcli!
-	
+
 This utility provides you with an easy way to interact
-with your Dialogflow CX agents. 
+with your Dialogflow CX agents.
 
 You can find the documentation at https://github.com/xavidop/dialogflow-cx-cli.
 
-Please file all bug reports on Github at https://github.com/xavidop/dialogflow-cx-cli/issues.`,
+Please file all bug reports on GitHub at https://github.com/xavidop/dialogflow-cx-cli/issues.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			if err := cmd.Help(); err != nil {

--- a/docs/docs/agents/delete.md
+++ b/docs/docs/agents/delete.md
@@ -3,24 +3,24 @@
 
 ## Usage
 
-You can find the delete command usage down the `cxcli agent delete` command. You can read the documentation about this command [here](/cmd/cxcli_agent_delete).
+You can find the delete functionality within the `cxcli agent delete` subcommand. You can read the documentation about this command [here](/cmd/cxcli_agent_delete).
 
 
 ## Example
 
-This a simple example of the `cxcli agent delete` command:
+Here is a simple example of the `cxcli agent delete` command:
 
 ```sh
 cxcli agent delete test-agent --project-id test-cx-346408 --location-id us-central1
 ```
 
-The command above will give you an output like this one:
+The above command will give you output similar to the following:
 
 ```sh
 $ cxcli agent delete test-agent --project-id test-cx-346408 --location-id us-central1
-INFO Agent deleted                          
+INFO Agent deleted
 ```
 
 ## Useful Links
 
-If you want to learn more about Dialogflow CX Agent deletion, check the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/agent).
+If you want to learn more about Dialogflow CX Agent deletion, refer to the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/agent).

--- a/docs/docs/agents/export.md
+++ b/docs/docs/agents/export.md
@@ -3,7 +3,7 @@
 
 ## Usage
 
-You can find the export command usage down the `cxcli agent export` command. You can read the documentation about this command [here](/cmd/cxcli_agent_export).
+You can find the export functionality within the `cxcli agent export` subcommand. You can read the documentation about this command [here](/cmd/cxcli_agent_export).
 
 
 !!! info "Exported file format"
@@ -12,21 +12,21 @@ You can find the export command usage down the `cxcli agent export` command. You
 
 ## Example
 
-This a simple example of the `cxcli agent export` command:
+Here is a simple example of the `cxcli agent export` command:
 
 ```sh
 cxcli agent export test-agent --project-id test-cx-346408 --location-id us-central1 --export-format blob
 ```
 
-The command above will give you an output like this one:
+The above command will give you output similar to the following:
 
 ```sh
 $ cxcli agent export test-agent --project-id test-cx-346408 --location-id us-central1 --export-format json --output-file agent.zip
-INFO Agent exported to file: agent.zip                    
+INFO Agent exported to file: agent.zip
 ```
-!!! info "are you running this command in a CICD pipeline?"
-    If this is the case, we recommend you to execute with the `--output-format` parameter set to `json`.
+!!! info "are you running this command in a CI/CD pipeline?"
+    If this is the case, we recommend that you set the `--output-format` parameter to `json`.
 
 ## Useful Links
 
-If you want to learn more about Dialogflow CX exports, check the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/agent#export).
+If you want to learn more about Dialogflow CX exports, refer to the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/agent#export).

--- a/docs/docs/agents/introduction.md
+++ b/docs/docs/agents/introduction.md
@@ -6,29 +6,29 @@ An agent in Dialogflow CX is the entity that handles all the conversations that 
 
 An agent is basically an assistant that will manage the state of each user's conversation when the end users are interacting with the agent through text or audio in multiple channels.
 
-With the `cxcli` you can interact easily with your Dialogflow CX agents.
+With `cxcli`, you can easily interact with your Dialogflow CX agents.
 
-All the commands that you have available in the `cxcli` to interact with your agents are located down the `cxcli agent` command.
+All of the commands that are available in `cxcli` to interact with your agents are located within the `cxcli agent` subcommand.
 
 ## Restore
 
 You can restore an agent using a `blob` or a `json-package` file. Right now the Dialogflow CX API, used by the `cxcli`, works with the `blob` and `json` format.
 
-The `cxcli` has a command that allows you to restore an agent. You can find the whole explanation [here](/agents/restore)
+The `cxcli` has a command that allows you to restore an agent. You can find a more detailed explanation [here](/agents/restore)
 
 
 ## Export
 
 An agent can be exported as a `blob` or a `json-package` file. Right now the Dialogflow CX API, used by the `cxcli`, works with the `blob` and `json` format.
 
-The `cxcli` has a command that allows you to export your agent. You can find the whole explanation [here](/agents/export)
+The `cxcli` has a command that allows you to export your agent. You can find a more detailed explanation [here](/agents/export)
 
 ## Delete
 
-The `cxcli` has a command that allows you to delete your agent. You can find the whole explanation [here](/agents/delete)
+The `cxcli` has a command that allows you to delete your agent. You can find a more detailed explanation [here](/agents/delete)
 
 ## Useful Links
 
-If you want to check the full usage of the `cxcli agent` command, please refer to this [page](/cmd/cxcli_agent).
+If you want to see the full usage of the `cxcli agent` command, please refer to this [page](/cmd/cxcli_agent).
 
-If you want to learn more about Dialogflow CX agents, check the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/agent).
+If you want to learn more about Dialogflow CX agents, refer to the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/agent).

--- a/docs/docs/agents/restore.md
+++ b/docs/docs/agents/restore.md
@@ -3,7 +3,7 @@
 
 ## Usage
 
-You can find the restore command usage down the `cxcli agent restore` command. You can read the documentation about this command [here](/cmd/cxcli_agent_restore).
+You can find the restore functionality within the `cxcli agent restore` subcommand. You can read the documentation about this command [here](/cmd/cxcli_agent_restore).
 
 
 !!! info "File format to be restored"
@@ -11,21 +11,21 @@ You can find the restore command usage down the `cxcli agent restore` command. Y
 
 ## Example
 
-This a simple example of the `cxcli agent restore` command:
+Here is a simple example of the `cxcli agent restore` command:
 
 ```sh
 cxcli agent restore test-agent --project-id test-cx-346408 --location-id us-central1 --input agent.blob
 ```
 
-The command above will give you an output like this one:
+The above command will give you output similar to the following:
 
 ```sh
 $ cxcli agent restore test-agent --project-id test-cx-346408 --location-id us-central1 --input agent.zip
-INFO Agent restored 
+INFO Agent restored
 ```
-!!! info "are you running this command in a CICD pipeline?"
-    If this is the case, we recommend you to execute with the `--output-format` parameter set to `json`.
+!!! info "Are you running this command in a CI/CD pipeline?"
+    If this is the case, we recommend that you set the `--output-format` parameter to `json`.
 
 ## Useful Links
 
-If you want to learn more about Dialogflow CX restores, check the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/agent#export).
+If you want to learn more about Dialogflow CX restores, refer to the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/agent#export).

--- a/docs/docs/cmd/cxcli.md
+++ b/docs/docs/cmd/cxcli.md
@@ -5,13 +5,13 @@ Dialogflow CX CLI
 ## Synopsis
 
 Welcome to cxcli!
-	
+
 This utility provides you with an easy way to interact
-with your Dialogflow CX agents. 
+with your Dialogflow CX agents.
 
 You can find the documentation at https://github.com/xavidop/dialogflow-cx-cli.
 
-Please file all bug reports on Github at https://github.com/xavidop/dialogflow-cx-cli/issues.
+Please file all bug reports on GitHub at https://github.com/xavidop/dialogflow-cx-cli/issues.
 
 ```
 cxcli [flags]
@@ -42,4 +42,3 @@ cxcli [flags]
 * [cxcli tts](/cmd/cxcli_tts/)	 - Actions on text-to-speech commands
 * [cxcli version](/cmd/cxcli_version/)	 - Get cxcli version
 * [cxcli webhook](/cmd/cxcli_webhook/)	 - Actions on webhook commands
-

--- a/docs/docs/cmd/cxcli_environment.md
+++ b/docs/docs/cmd/cxcli_environment.md
@@ -26,6 +26,5 @@ cxcli environment [flags]
 * [cxcli](/cmd/cxcli/)	 - Dialogflow CX CLI
 * [cxcli environment create](/cmd/cxcli_environment_create/)	 - create an environment
 * [cxcli environment delete](/cmd/cxcli_environment_delete/)	 - delete an environment
-* [cxcli environment execute-cicd](/cmd/cxcli_environment_execute-cicd/)	 - Executes a CICD pipeline for a specific environment
+* [cxcli environment execute-cicd](/cmd/cxcli_environment_execute-cicd/)	 - Executes a CI/CD pipeline for a specific environment
 * [cxcli environment update](/cmd/cxcli_environment_update/)	 - update an environment
-

--- a/docs/docs/cmd/cxcli_environment_execute-cicd.md
+++ b/docs/docs/cmd/cxcli_environment_execute-cicd.md
@@ -1,6 +1,6 @@
 # cxcli environment execute-cicd
 
-Executes a CICD pipeline for a specific environment
+Executes a CI/CD pipeline for a specific environment
 
 ```
 cxcli environment execute-cicd [environment] [flags]
@@ -27,4 +27,3 @@ cxcli environment execute-cicd [environment] [flags]
 ## See also
 
 * [cxcli environment](/cmd/cxcli_environment/)	 - Actions on environment
-

--- a/docs/docs/community/contributing.md
+++ b/docs/docs/community/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-By participating in this project, you agree to abide our
+By participating in this project, you agree to abide by our
 [code of conduct](https://github.com/xavidop/dialogflow-cx-cli/blob/master/CODE_OF_CONDUCT.md).
 
 ## Set up your machine
@@ -31,7 +31,7 @@ git clone git@github.com:xavidop/dialogflow-cx-cli.git
 go mod tidy
 ```
 
-A good way of making sure everything is all right is running the build:
+A good way of making sure everything is all right is by running the build:
 
 ```sh
 go build -o cxcli .
@@ -59,5 +59,5 @@ Push your branch to your `cxcli` fork and open a pull request against the main b
 
 ## Financial contributions
 
-You can contribute in our Github Sponsors or to any of the contributors directly.
+You can contribute in our GitHub Sponsors or to any of the contributors directly.
 See [this page](https://cxcli.xavidop.me/sponsors) for more details.

--- a/docs/docs/community/sponsors.md
+++ b/docs/docs/community/sponsors.md
@@ -6,7 +6,7 @@ project and its maintainers.
 
 ## GitHub Sponsors
 
-GitHub Sponsors is a great way to contribute directly to the main maintainer,
+GitHub Sponsors is a great way to contribute directly to the primary maintainer,
 [xavidop](https://github.com/xavidop).
 
 This money usually goes to buying coffee, beer, better hardware, and, hopefully,

--- a/docs/docs/community/users.md
+++ b/docs/docs/community/users.md
@@ -1,6 +1,6 @@
 ## Who uses cxcli?
 
-As the cxcli Community grows, we'd like to keep a list of our users.
+As the cxcli community grows, we'd like to keep a list of our users.
 
 Here's a running list of some organizations using cxcli[^1]:
 

--- a/docs/docs/entitytypes/create.md
+++ b/docs/docs/entitytypes/create.md
@@ -3,31 +3,31 @@
 
 ## Usage
 
-You can find the create command usage down the `cxcli entity-type create` command. You can read the documentation about this command [here](/cmd/cxcli_entity-type_create).
+You can find the create functionality within the `cxcli entity-type create` subcommand. You can read the documentation about this command [here](/cmd/cxcli_entity-type_create).
 
 
-The `--entities` is a list of the entities with their synonyms, comma separated. This parameter has the following format: 
+The argument to `--entities` is a list of the entities with their synonyms, comma separated. This parameter has the following format:
 ```
 entity1@synonym1|synonym2,entity2@synonym1|synonym2
 ```
 
-Here you have an example: `pikachu@25|pika,charmander@3`
+An example entity type with synonyms: `pikachu@25|pika,charmander@3`
 
 ## Example
 
-This a simple example of the `cxcli entity-type create` command:
+Here is a simple example of the `cxcli entity-type create` command:
 
 ```sh
 cxcli entity-type create pokemon --entities "pikachu@25|pika,charmander@3" --agent-name test-agent --project-id test-cx-346408 --location-id us-central1
 ```
 
-The command above will give you an output like this one:
+The above command will give you output similar to the following:
 
 ```sh
 $ cxcli entity-type create pokemon --entities "pikachu@25|pika,charmander@3" --agent-name test-agent --project-id test-cx-346408 --location-id us-central1
-INFO Entity Type created with id: projects/test-cx-346408/locations/us-central1/agents/40278ea0-c0fc-4d9a-a4d4-caa68d86295f/entityTypes/457a451d-f5ce-47da-b8dc-16b17d874a5d 
+INFO Entity Type created with id: projects/test-cx-346408/locations/us-central1/agents/40278ea0-c0fc-4d9a-a4d4-caa68d86295f/entityTypes/457a451d-f5ce-47da-b8dc-16b17d874a5d
 ```
 
 ## Useful Links
 
-If you want to learn more about Dialogflow CX Entity types creation, check the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/entity).
+If you want to learn more about Dialogflow CX entity types creation, refer to the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/entity).

--- a/docs/docs/entitytypes/delete.md
+++ b/docs/docs/entitytypes/delete.md
@@ -3,24 +3,24 @@
 
 ## Usage
 
-You can find the delete command usage down the `cxcli entity-type delete` command. You can read the documentation about this command [here](/cmd/cxcli_entity-type_delete).
+You can find the delete functionality within the `cxcli entity-type delete` subcommand. You can read the documentation about this command [here](/cmd/cxcli_entity-type_delete).
 
 
 ## Example
 
-This a simple example of the `cxcli entity-type delete` command:
+Here is a simple example of the `cxcli entity-type delete` command:
 
 ```sh
 cxcli entity-type delete pokemon2  --agent-name test-agent --project-id test-cx-346408 --location-id us-central1
 ```
 
-The command above will give you an output like this one:
+The above command will give you output similar to the following:
 
 ```sh
 $ cxcli entity-type delete pokemon2  --agent-name test-agent --project-id test-cx-346408 --location-id us-central1
-INFO Entity Type deleted                          
+INFO Entity Type deleted
 ```
 
 ## Useful Links
 
-If you want to learn more about Dialogflow CX entity types deletion, check the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/entity).
+If you want to learn more about Dialogflow CX entity types deletion, refer to the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/entity).

--- a/docs/docs/entitytypes/introduction.md
+++ b/docs/docs/entitytypes/introduction.md
@@ -2,35 +2,35 @@
 
 ## What is this?
 
-One of the most important parts of NLU is the Entity types or entities. These are the key information in a text, such as names, dates, products, organizations, places, or anything we want to extract from the text. We call this concept “Entities”. For example, let's take a look at the `order_intent` intent:
+One of the most important aspects of natural language understanding is entity types or entities. Entities contain the important factors within a message such as names, dates, products, organizations, places, or anything that we want to extract from the message. We call this concept “entities”. For example, let's take a look at the `order_intent` intent:
 
 1. I want a pizza
 2. I want 3 cokes
 3. Give me two burgers
 
-As you can see in the example above, we can extract 2 Entity Types: `quantity` and `order_type`. We can extrapolate the utterances above like this:
+As you can see in the example above, we can extract two entity Types: `quantity` and `order_type`. We can represent the entities within the above utterances as:
 
 1. I want `{quantity}` `{order_type}`
 2. Give me `{quantity}` `{order_type}`
 
-We can think about Entity Types as variables as well.
+We can also think of entity types as variables.
 
-With the `cxcli` you can interact easily with your Dialogflow CX entity types.
+With `cxcli`, you can easily interact with your Dialogflow CX entity types.
 
-All the commands that you have available in the `cxcli` to interact with your agents are located down the `cxcli entity-type` command.
+All of the commands that you have available in `cxcli` to interact with your entity types are located within the `cxcli entity-type` subcommand.
 
 ## Create
 
-The `cxcli` has a command that allows you to create an entity type. You can find the whole explanation [here](/entitytypes/create)
+The `cxcli` has a command that allows you to create an entity type. You can find a more detailed [here](/entitytypes/create).
 
 
 ## Delete
 
-The `cxcli` has a command that allows you to delete your entity type. You can find the whole explanation [here](/entitytypes/delete)
+The `cxcli` has a command that allows you to delete your entity type. You can find a more detailed explanation [here](/entitytypes/delete).
 
 
 ## Useful Links
 
-If you want to check the full usage of the `cxcli entity-type` command, please refer to this [page](/cmd/cxcli_entity-type).
+If you want to see the full usage of the `cxcli entity-type` command, please refer to this [page](/cmd/cxcli_entity-type).
 
-If you want to learn more about Dialogflow CX entity types, check the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/entity).
+If you want to learn more about Dialogflow CX entity types, refer to the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/entity).

--- a/docs/docs/environments/cicd.md
+++ b/docs/docs/environments/cicd.md
@@ -1,29 +1,29 @@
-# Environments CICD
+# Environments CI/CD
 
 ## Usage
 
-You can find the cicd command usage down the `cxcli environment execute-cicd` command. You can read the documentation about this command [here](/cmd/cxcli_environment_execute-cicd).
+You can find the CI/CD functionality within the `cxcli environment execute-cicd` subcommand. You can read the documentation about this command [here](/cmd/cxcli_environment_execute-cicd).
 
 ## Example
 
-This a simple example of the `cxcli environment execute-cicd` command:
+Here is a simple example of the `cxcli environment execute-cicd` command:
 
 ```sh
 cxcli environment execute-cicd cicd-env --project-id test-cx-346408 --location-id us-central1 --agent-name test-agent
 ```
 
-The command above will give you an output like this one:
+The above command will give you output similar to the following:
 
 ```sh
 $ cxcli environment execute-cicd cicd-env --project-id test-cx-346408 --location-id us-central1 --agent-name test-agent
-INFO Executing cicd for environment cicd-env      
-INFO PASSED                     
+INFO Executing cicd for environment cicd-env
+INFO PASSED
 ```
 
-!!! info "are you running this command in a CICD pipeline?"
-    If this is the case, we recommend you to execute with the `--output-format` parameter set to `json`.
+!!! info "Are you running this command in a CI/CD pipeline?"
+    If this is the case, we recommend that you set the `--output-format` parameter to `json`.
 
 
 ## Useful Links
 
-If you want to learn more about Dialogflow CX cicd executions, check the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/continuous-tests).
+If you want to learn more about Dialogflow CX CI/CD execution, refer to the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/continuous-tests).

--- a/docs/docs/environments/introduction.md
+++ b/docs/docs/environments/introduction.md
@@ -2,22 +2,22 @@
 
 ## What is this?
 
-In software, it is a common pattern (and a best practice) to have different environments where developers can deploy different versions of their software. Each environment has its own configurations.
+In software, it is a common pattern (and a best practice) to have different environments where developers can deploy different versions of their software. Each environment has its own configuration.
 
-In Dialogflow CX we have the same concept, you can create a version of your agent and then, deploy it to an environment. Same with the webhook, you can deploy a webhook version and use that version in an environment.
+Dialogflow CX follows the same concept in that you can create a version of your agent and then deploy it to a specific environment. This is also similar to a webhook in that you can deploy a specific webhook version and use that version within an environment.
 
-With the `cxcli` you can interact easily with the environments of your Dialogflow CX agents.
+With `cxcli`, you can easily interact with the environments of your Dialogflow CX agents.
 
-All the commands that you have available in the `cxcli` to interact with your environments are located down the `cxcli environment` command.
+All of the commands that you have available in `cxcli` to interact with your environments are located within the `cxcli environment` subcommand.
 
-## CICD
+## CI/CD
 
-In Dialogflow CX, while you are testing your agents, you can save those tests and associate them to a specific environment.
+In Dialogflow CX, when you are testing your agents, you can save those tests and associate them with a specific environment.
 
-The `cxcli` has a command that allows you to run these cicd pipelines from your terminal or from your CI processes. You can find the whole explanation [here](/environments/cicd)
+The `cxcli` tool has a command that allows you to run these CI/CD pipelines from your terminal or from your CI processes. You can find a more detailed explanation [here](/environments/cicd).
 
 ## Useful Links
 
-If you want to check the full usage of the `cxcli environment` command, please refer to this [page](/cmd/cxcli_environment).
+If you want to see the full usage of the `cxcli environment` command, please refer to this [page](/cmd/cxcli_environment).
 
-If you want to learn more about Dialogflow CX environments, check the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/version).
+If you want to learn more about Dialogflow CX environments, refer to the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/version).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -5,10 +5,10 @@
 </p>
 
 
-`cxcli` is a tool that helps Dialogflow CX users to test their projects and interact with them in multiple ways.
-It is useful for your day-today taks or if you want to integrate it in your favorite CI.
+`cxcli` is a command-line tool that helps Dialogflow CX users test their agents and interact with them in various ways.
+It is useful for your day-to-day tasks or if you want to integrate it with your favorite CI tool.
 
-This CLI also has [text-to-speech](/tts) and [speech-to text](stt) capabilities allowing the interaction with Google Cloud Platform APIs.
+This CLI also allows you to interact with the [text-to-speech](/tts) and [speech-to text](/stt) APIs in Google Cloud.
 
 ## Get started
 
@@ -20,9 +20,8 @@ This CLI also has [text-to-speech](/tts) and [speech-to text](stt) capabilities 
 
 `cxcli` is developed by [xavidop](https://github.com/xavidop).
 
-You can contact us via email at: [dialogflowcxcli@gmail.com](mailto:dialogflowcxcli@gmail.com)
+You can contact us via email at: [dialogflowcxcli@gmail.com](mailto:dialogflowcxcli@gmail.com).
 
-Follow [@dialogflowcxcli on Twitter](https://twitter.com/dialogflowcxcli) for updates and announcements
+Follow [@dialogflowcxcli on Twitter](https://twitter.com/dialogflowcxcli) for updates and announcements.
 
-Visit our [links](/links) section for more information about how stay in touch with us
-
+Visit our [links](/links) section for more information about staying connected with us.

--- a/docs/docs/intents/create.md
+++ b/docs/docs/intents/create.md
@@ -3,32 +3,32 @@
 
 ## Usage
 
-You can find the create command usage down the `cxcli intent create` command. You can read the documentation about this command [here](/cmd/cxcli_intent_create).
+You can find the create functionality within the `cxcli intent create` subcommand. You can read the documentation about this command [here](/cmd/cxcli_intent_create).
 
 
-The `--training-phrases` parameter is a list of the training phrases for this intent, comma separated. For the entities used in this intent, add `@entity-type` to the word in the training phrase. This is the format: 
+The `--training-phrases` parameter is a list of the training phrases for this intent, comma separated. For the entities used in this intent, add `@entity-type` to the word in the training phrase. This is the format:
 
 ```
 word@entity-type
 ```
 
-Here you have an example: `hello, hi how are you today@sys.date, morning!`
+An example training phrase with a entity: `hello, hi how are you today@sys.date, morning!`
 
 ## Example
 
-This a simple example of the `cxcli intent create` command:
+Here is a simple example of using the `cxcli intent create` command:
 
 ```sh
 cxcli intent create test_intent --training-phrases "hello, hi how are you today@sys.date, morning"  --agent-name test-agent --project-id test-cx-346408 --location-id us-central1
 ```
 
-The command above will give you an output like this one:
+The above command will give you output similar to the following:
 
 ```sh
 $ cxcli intent create test_intent --training-phrases "hello, hi how are you today@sys.date, morning"  --agent-name test-agent --project-id test-cx-346408 --location-id us-central1
-INFO Intent created with id: projects/test-cx-346408/locations/us-central1/agents/40278ea0-c0fc-4d9a-a4d4-caa68d86295f/intents/a7870357-e942-43dd-99d2-4de8c81a3c09 
+INFO Intent created with id: projects/test-cx-346408/locations/us-central1/agents/40278ea0-c0fc-4d9a-a4d4-caa68d86295f/intents/a7870357-e942-43dd-99d2-4de8c81a3c09
 ```
 
 ## Useful Links
 
-If you want to learn more about Dialogflow CX Intent creation, check the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/intent).
+If you want to learn more about Dialogflow CX intent creation, refer to the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/intent).

--- a/docs/docs/intents/delete.md
+++ b/docs/docs/intents/delete.md
@@ -3,24 +3,24 @@
 
 ## Usage
 
-You can find the delete command usage down the `cxcli intent delete` command. You can read the documentation about this command [here](/cmd/cxcli_intent_delete).
+You can find the delete functionality within the `cxcli intent delete` subcommand. You can read the documentation about this command [here](/cmd/cxcli_intent_delete).
 
 
 ## Example
 
-This a simple example of the `cxcli intent delete` command:
+Here is a simple example of the `cxcli intent delete` command:
 
 ```sh
 cxcli intent delete test_intent --agent-name test-agent --project-id test-cx-346408 --location-id us-central1
 ```
 
-The command above will give you an output like this one:
+The above command will give you output similar to the following:
 
 ```sh
 $ cxcli intent delete test_intent --agent-name test-agent --project-id test-cx-346408 --location-id us-central1
-INFO Intent deleted                     
+INFO Intent deleted
 ```
 
 ## Useful Links
 
-If you want to learn more about Dialogflow CX Intent creation, check the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/intent).
+If you want to learn more about Dialogflow CX intent deletion, refer to the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/intent).

--- a/docs/docs/intents/introduction.md
+++ b/docs/docs/intents/introduction.md
@@ -2,33 +2,36 @@
 
 ## What is this?
 
-Before start talking about intents, it is important to understand what is NLU. The Natural Language Understanding (NLU) is a subset of Natural Language Processing (NLP). It helps a "machine" to be able to understand human language.
-In Dialogflow CX this is an important part, since it will help predicting the user's intention and allowing us to act in a more "smart" way, and avoid the already typical: "I did not understand you, could you repeat it?". We call these intentions, proposals or user requests, which the machine must classify. These are the "Intents". Each intent has training phrases. For example the `welcome_intent` intent can have these 3 training phrases:
+Before we discuss intents, it is important to first understand what is natural language understanding (NLU). Natural language understanding is a subset of natural language processing (NLP). It helps a "machine" to be able to understand human language.
+
+In Dialogflow CX, this is an important concept, since it will help predict the user's intention and allow us to act in a "smarter" way, and avoid the all-too-common default fallback intent: "I did not understand you, could you repeat?".
+
+We refer to these intentions, proposals, or user requests that machine must classify as "intents". Each intent has training phrases. For example, the default `welcome_intent` intent can contain these three training phrases:
 
 1. Hi
 2. Hello
 3. Whats up!
 
-As you can see in the example above, our intention with the `welcome_intent` intent is to start a conversation when a user says any of these training phrases. An intent can have multiple entities.
+As you can see in the example above, the purpose of the `welcome_intent` intent is to start a conversation when a user says any of these training phrases. An intent can have multiple entities.
 
-Whenever you create, modify or deletes an intent it is important to re-train your Dialogflow CX flows. This will re-train your NLU. By doing this your bot will "understand you" including your latest changes.
+Whenever you create, modify, or delete an intent, it is important to re-train your Dialogflow CX flows. This will re-train your NLU model. By doing this, your bot will "understand you", including your latest changes.
 
-With the `cxcli` you can interact easily with your Dialogflow CX intents.
+With `cxcli`, you can easily interact with your Dialogflow CX intents.
 
-All the commands that you have available in the `cxcli` to interact with your agents are located down the `cxcli intents` command.
+All of the commands that you have available in `cxcli` to interact with your intents are located within the `cxcli intents` subcommand.
 
 ## Create
 
-The `cxcli` has a command that allows you to create an intents. You can find the whole explanation [here](/intents/create)
+The `cxcli` has a command that allows you to create an intent. You can find a more detailed explanation [here](/intents/create)
 
 
 ## Delete
 
-The `cxcli` has a command that allows you to delete your intents. You can find the whole explanation [here](/intents/delete)
+The `cxcli` has a command that allows you to delete your intents. You can find a more detailed explanation [here](/intents/delete)
 
 
 ## Useful Links
 
-If you want to check the full usage of the `cxcli intents` command, please refer to this [page](/cmd/cxcli_intent).
+If you want to see the full usage of the `cxcli intents` command, please refer to this [page](/cmd/cxcli_intent).
 
-If you want to learn more about Dialogflow CX intents, check the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/intent).
+If you want to learn more about Dialogflow CX intents, refer to the [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/intent).

--- a/docs/docs/links.md
+++ b/docs/docs/links.md
@@ -1,12 +1,12 @@
 # Links
 
-- Follow the progress on the [GitHub repository](https://github.com/xavidop/dialogflow-cx-cli)
+- Follow our progress on the [GitHub repository](https://github.com/xavidop/dialogflow-cx-cli)
 - Follow us on [Twitter](https://twitter.com/dialogflowcxcli) and
 <a rel="me" href="https://fosstodon.org/@dialogflowcxcli">Mastodon</a>
 for updates
 - Join our [Discord server](https://discord.gg/7wMnbaPE4n)
 - Read my [blog](https://xavidop.me)
-- Sign up for my [Newsletter](https://www.getrevue.co/profile/xavidop)
+- Sign up for my [newsletter](https://www.getrevue.co/profile/xavidop)
 - For questions, support and general discussion, please use
 [Discord](https://discord.gg/7wMnbaPE4n) or
 [GitHub Discussions](https://github.com/xavidop/dialogflow-cx-cli/discussions)
@@ -16,4 +16,3 @@ for updates
 This project adheres to the Contributor Covenant
 [code of conduct](https://github.com/xavidop/dialogflow-cx-cli/blob/master/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code.
-

--- a/docs/docs/nluprofiler/introduction.md
+++ b/docs/docs/nluprofiler/introduction.md
@@ -8,55 +8,55 @@
 
 Use the NLU Profiler to test user utterances and improve your agent's interaction model.
 
-With the NLU Profiler, you can see how utterances resolve to intents and slots in your interaction model. When an utterance doesn't resolve to the right intent or slot, you can update the interaction model and try again. With the `cxcli`, you can see what intents Dialogflow CX considered and discarded. Then, you can determine how to use additional samples to train your model to resolve utterances to their intended intents and slots.
+With the NLU Profiler, you can see how utterances resolve to intents and slots in your interaction model. When an utterance doesn't resolve to the right intent or slot, you can update the interaction model and try again. With the `cxcli`, you can see which intents Dialogflow CX considered and discarded. Then, you can determine how to use additional samples to train your model to resolve utterances to their desired intents and slots.
 
 Every suite is executed in the Dialogflow CX session so you can test not only your NLU but also a conversation itself.
 
-All the commands that you have available in the `cxcli` to execute the NLU profiler are located down the [`cxcli profile-nlu` command](/cmd/cxcli_profile-nlu).
+All of the commands that are available in `cxcli` to execute the NLU profiler are located within the [`cxcli profile-nlu` subcommand](/cmd/cxcli_profile-nlu).
 
 ## Reference
 
-It is important to know which [suites](/nluprofiler/suites) and [tests](/nluprofiler/tests) you can build. Because of that, you can find the entire reference in the [Reference](/nluprofiler/suites) page. Suites and test are defined as `yaml` files.
+It is important to know which [suites](/nluprofiler/suites) and [tests](/nluprofiler/tests) you can build. Because of that, you can find the entire reference on the [Reference](/nluprofiler/suites) page. Suites and test are defined as `yaml` files.
 
 The `cxcli` has a command that allows you to run these suites from your terminal or from your CI pipelines.
 
-To execute a suite, you have to run the `cxcli profile-nlu execute` command. For the usage, please refer to this [page](/cmd/cxcli_profile-nlu_execute).
+To execute a suite, you can run the `cxcli profile-nlu execute` command. For the usage, please refer to this [page](/cmd/cxcli_profile-nlu_execute).
 
 ## Examples
 
-You can find some useful examples on our [Github repo](https://github.com/xavidop/dialogflow-cx-cli/tree/master/examples) and the [Examples](/nluprofiler/examples) page.
+You can find some useful examples on our [GitHub repo](https://github.com/xavidop/dialogflow-cx-cli/tree/master/examples) and the [Examples](/nluprofiler/examples) page.
 
 
 ## Execution Example
 
-This a simple example of the `cxcli profile-nlu execute` command:
+Here is a simple example of the `cxcli profile-nlu execute` command:
 
 ```sh
 cxcli profile-nlu execute examples/suite.yaml
 ```
 
-The command above will give you an output similar to this one:
+The above command will give you output similar to the following:
 
 ```sh
 $ cxcli profile-nlu execute suite.yaml
-INFO Suite Information: test-agent                
-INFO Test ID: test_1                              
-INFO Input: type: text, value: hi                 
-INFO Intent Detected: hi_intent                   
-INFO Input: type: text, value: hello              
-INFO Intent Detected: hi_intent                   
-INFO Input: type: audio, value: ./audio/hi.mp3    
-INFO Intent Detected: hi_intent                   
-INFO Test ID: test_2                              
-INFO Input: type: text, value: I want 3 pizzas    
-INFO Intent Detected: order_intent                
-INFO Param order_type: pizza                      
-INFO Param number: 3                              
-INFO Input: type: text, value: I want 2 cokes     
-INFO Intent Detected: order_intent                
-INFO Param number: 2                              
-INFO Param order_type: coke                        
+INFO Suite Information: test-agent
+INFO Test ID: test_1
+INFO Input: type: text, value: hi
+INFO Intent Detected: hi_intent
+INFO Input: type: text, value: hello
+INFO Intent Detected: hi_intent
+INFO Input: type: audio, value: ./audio/hi.mp3
+INFO Intent Detected: hi_intent
+INFO Test ID: test_2
+INFO Input: type: text, value: I want 3 pizzas
+INFO Intent Detected: order_intent
+INFO Param order_type: pizza
+INFO Param number: 3
+INFO Input: type: text, value: I want 2 cokes
+INFO Intent Detected: order_intent
+INFO Param number: 2
+INFO Param order_type: coke
 ```
 
-!!! info "are you running this command in a CICD pipeline?"
-    If this is the case, we recommend you to execute with the `--output-format` parameter set to `json`.
+!!! info "Are you running this command in a CI/CD pipeline?"
+    If this is the case, we recommend that you set the `--output-format` parameter to `json`.

--- a/docs/docs/nluprofiler/tests.md
+++ b/docs/docs/nluprofiler/tests.md
@@ -11,7 +11,7 @@ A test is a yaml file with the following structure:
 name: Example test
 # Brief description of the test.
 description: These are some tests
-# Locale of the interaction model that is gonna be tested. 
+# Locale of the interaction model that is gonna be tested.
 # You can find the locales here: https://cloud.google.com/dialogflow/cx/docs/reference/language
 localeId: en
 # A check is the test itself: given an input, you will validate the intents and the parameters/entities detected by Dialogflow CX
@@ -39,10 +39,10 @@ checks:
 
 ## Audio input
 
-It is important to know that the input has to have this format:
+It is important to know that the input audio needs to have the following format:
 
-1. A Sample Rate Hertz of 16000Hz
-2. The audio encoding has to be be Linear16. Linear16 is a 16-bit linear pulse-code modulation (PCM) encoding.
+1. A sample rate of 16000 Hertz
+2. The audio encoding has to be Linear16. Linear16 is a 16-bit linear pulse-code modulation (PCM) encoding.
 
 If you don't have a file with this format, you can create it by yourself using the `cxcli tts` command! All the information is located [here](/tts)
 

--- a/docs/docs/overview/authentication.md
+++ b/docs/docs/overview/authentication.md
@@ -1,10 +1,10 @@
 # Authentication
 
-`cxcli` uses some Google cloud APIs. By default the tool uses the default configuration that uses the `gcloud` cli. If you want to use another authentication key you can provide a `json` file with the global `--credentials` parameter.
+`cxcli` uses various Google Cloud APIs. By default, the tool uses the default configuration that uses the `gcloud` cli. If you want to use another authentication key you can provide a `json` file with the global `--credentials` parameter.
 
 The `cxcli` source code is open source, you can check it out [here](https://github.com/xavidop/dialogflow-cx-cli) to learn more about the actions the tool performs.
 
-Below you can find the roles and the APIs needed to use the tool.
+Below you can find the roles and the APIs that are required to use this tool.
 
 ## Roles needed
 
@@ -18,7 +18,7 @@ This role allows you to execute Speech-to-text and Text-to-speech actions
 
 ## APIs enabled needed
 
-These APIs should be enabled on your Google Cloud project if you want to use these `cxcli` capabilities:
+The following APIs should be enabled on your Google Cloud project if you want to use the respective `cxcli` capabilities:
 
 ### Dialogflow CX
 
@@ -31,4 +31,3 @@ You will need to enable the `Cloud Speech-to-Text API` on your project. More inf
 ### Text-to-speech
 
 You will need to enable the `Cloud Text-to-Speech API` on your project. More information [here](https://cloud.google.com/text-to-speech/docs/apis)
-

--- a/docs/docs/overview/faq.md
+++ b/docs/docs/overview/faq.md
@@ -4,30 +4,30 @@
 
 `cxcli` has three main purposes:
 
-1. Make the interaction with you Dialogflow CX projects from you laptops or your continuous integration pipelines easier than ever
-2. Create testing tools that will help users to build their dialogflow CX agent
-3. Interact with other Google Cloud APIs such as TTS and STT ones in a super easy way
+1. Make the interaction with your Dialogflow CX agents from your laptop or your continuous integration pipelines easier than ever
+2. Create testing tools that will help users build their Dialogflow CX agent
+3. Interact with other Google Cloud APIs such as TTS and STT in a very easy way
 
 ## Who is `cxcli` for?
 
-`cxcli` is primarily for software engineering teams who are currently using Dialogflow CX. It is recommended for Machine learning engineers that usually work with STT, TTS, NLU and NLP technologies.
+`cxcli` is primarily for software engineering teams who are currently using Dialogflow CX. It is recommended for machine learning engineers that usually work with STT, TTS, NLU and NLP technologies.
 
 ## What kind of machines/containers do I need for the `cxcli`?
 
-You'll need either: a bare-metal host (your own, AWS i3.metal or Equinix Metal), a VM that supports nested virtualisation such as those provided by GCP, Azure, AWS DigitalOcean, etc or a linux or windows container.
+You'll need either: a bare-metal host (your own, AWS i3.metal or Equinix Metal) or a VM that supports nested virtualisation such as those provided by Google Cloud, Azure, AWS DigitalOcean, etc. or a Linux or Windows container.
 
 ## When will Jenkins, GitLab CI, BitBucket Pipeline Runners, Drone or Azure DevOps be supported?
 
 For the current phase, we're targeting GitHub Actions because it has fine-grained access controls and the ability to schedule exactly one build to a runner. The other CI systems will be available soon.
 
-That said, if you're using these tools within your organisation, we'd like to hear from you. 
+That said, if you're using these tools within your organisation, we'd like to hear from you.
 So feel free to reach out to us if you feel `cxcli` would be a good fit for your team.
 
 Feel free to contact us at: [dialogflowcxcli@gmail.com](mailto:dialogflowcxcli@gmail.com)
 
-## What kind of access is required to my Google Cloud project?
+## What kind of access is required in my Google Cloud project?
 
-Check the Authentication page [here](/overview/authentication)
+Refer to the Authentication page [here](/overview/authentication)
 
 ## Can cxcli be used on public repos?
 
@@ -41,21 +41,21 @@ The image is built automatically using GitHub Actions and is available on a cont
 
 ## Is ARM64 supported?
 
-Yes, `cxcli` is built to run on both Intel/AMD and ARM64 hosts. This includes a Raspberry Pi 4B, AWS Graviton, Oracle Cloud ARM instances and potentially any other ARM64 instances which support virtualisation.
+Yes, `cxcli` is built to run on both Intel/AMD and ARM64 hosts. This includes a Raspberry Pi 4B, AWS Graviton, Oracle Cloud ARM instances and potentially any other ARM64 instances that support virtualisation.
 
-## Are Windows or MacOS supported?
+## Are Windows or macOS supported?
 
-Yes, not only Linux, but also Windows and MacOS are supported platforms for `cxcli` at this time on a AMD64 or ARM64 architecture.
+Yes, in addition to Linux, Windows and macOS are also supported platforms for `cxcli` at this time on a AMD64 or ARM64 architecture.
 
 ## Is `cxcli` free and open-source?
 
-`cxcli` is an open source tool, however, it interacts with Google Cloud APIs so a GCP account is required.
+`cxcli` is an open source tool, however, it interacts with Google Cloud APIs, so a Google Cloud account is required.
 
-The website and documentation are available on GitHub and we plan to release some open source tools in the future for cxcli customers. 
+The website and documentation are available on GitHub and we plan to release some open source tools in the future for cxcli customers.
 
 ## Is there a risk that we could get "locked-in" to `cxcli`?
 
-No, you can move back to either `gcloud` cli or using the APIs itself at any time. Bear in mind that `cxcli` not only solves for a certain set of issues with both of those approaches but also simplifies the interaction with Google Cloud.
+No, you can switch back to using either the `gcloud` CLI tool or the Google Cloud APIs at any time. Keep in mind that `cxcli` not only solves for a certain set of issues with both of those approaches but also simplifies the interaction with Google Cloud.
 
 ## Why is the brand called "cxcli" and "Dialogflow CX CLI" ?
 

--- a/docs/docs/overview/install.md
+++ b/docs/docs/overview/install.md
@@ -1,13 +1,11 @@
 # Install
 
-You can install the pre-compiled binary (in several ways), using Docker or compiling it from source.
+You can use `cxcli` by installing a pre-compiled binary (in several ways), using Docker, or compiling it from source. In the below sections, you can find the steps for each approach.
 
-Below you can find the steps for each of them.
-
-## Install the pre-compiled binary
+## Install a pre-compiled binary
 
 ### homebrew tap
-1. Add the Hombrew tab:
+1. Add the Homebrew tap:
 ```sh
 brew tap xavidop/tap git@github.com:xavidop/homebrew-tap.git
 brew update
@@ -99,7 +97,7 @@ Download the pre-compiled binaries from the [releases page][releases] and copy t
 
 All artifacts are checksummed, and the checksum file is signed with [cosign][].
 
-1. Download the files you want, and the `checksums.txt`, `checksum.txt.pem` and `checksums.txt.sig` files from the [releases][releases] page:
+1. Download the files you want along with the `checksums.txt`, `checksum.txt.pem`, and `checksums.txt.sig` files from the [releases][releases] page:
     ```sh
     wget https://github.com/xavidop/dialogflow-cx-cli/releases/download/__VERSION__/checksums.txt
     wget https://github.com/xavidop/dialogflow-cx-cli/releases/download/__VERSION__/checksums.txt.sig
@@ -132,7 +130,7 @@ COSIGN_EXPERIMENTAL=1 cosign verify xavidop/cxcli
 
 ## Running with Docker
 
-You can also use it within a Docker container.
+You can also use `cxcli` within a Docker container.
 To do that, you'll need to execute something more-or-less like the examples below.
 
 Registries:
@@ -149,9 +147,8 @@ docker run --rm \
 
 Note that the image will almost always have the last stable Go version.
 
-If you need more things, you are encouraged to keep your own image. You can
-always use cxcli's [own Dockerfile][dockerfile] as an example though
-and iterate from that.
+If you need other packages and dependencies, you are encouraged to keep your own image. You can
+always use cxcli's [own Dockerfile][dockerfile] as a starting point and iterate on that.
 
 [dockerfile]: https://github.com/xavidop/dialogflow-cx-cli/blob/master/Dockerfile
 [releases]: https://github.com/xavidop/dialogflow-cx-cli/releases
@@ -185,7 +182,7 @@ go mod tidy
 go build -o cxcli .
 ```
 
-**verify it works:**
+**verify that it works:**
 
 ```sh
 ./cxcli version

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -8,13 +8,13 @@ For now, if you're interested in participating and giving feedback, we believe `
 
 Shipped:
 
-* [x] Available in homebrew, snapcraft, apt, yum, scoop, aur package managers 
+* [x] Available in homebrew, snapcraft, apt, yum, scoop, aur package managers
 * [x] Documentation updated
 * [x] Profile NLU
 * [x] Speech-to-text and Text-to-speech actions
 * [x] Container image available for multiple architectures
 * [x] SBOM files created
-* [x] Artifacts uploaded, signed and available on Github
+* [x] Artifacts uploaded, signed and available on GitHub
 
 Coming soon:
 

--- a/docs/docs/security.md
+++ b/docs/docs/security.md
@@ -6,4 +6,4 @@ Only the last stable version at any given point.
 
 ## Reporting a Vulnerability
 
-Vulnerabilities can be disclosed via email to dialogflowcxcli@gmail.com
+Vulnerabilities can be disclosed via email to dialogflowcxcli@gmail.com.

--- a/docs/docs/stt.md
+++ b/docs/docs/stt.md
@@ -1,54 +1,52 @@
 # Speech-to-text
 
 <p align="center">
-  <img alt="GCP TTS Logo" src="/images/stt.png" style="height:256px;width:256px" />
+  <img alt="Google Cloud TTS Logo" src="/images/stt.png" style="height:256px;width:256px" />
 </p>
 
-
-
-`cxcli` has some commands that allows you to interact with Google Cloud Text to Speech service using the `Cloud Speech-to-text API`!
+The `cxcli` tool has various commands that allow you to interact with Google Cloud's Speech to Text service using the `Cloud Speech-to-text API`!
 
 !!! info "Is this your first time using this feature?"
     Before you start using this functionality, please, read the [authentication](/overview/authentication) page.
 
 ## Usage
 
-You can find the speech-to-text commands usage down the `cxcli stt` command. You can read the documentation about this command [here](/cmd/cxcli_stt).
+You can find the speech-to-text functionality within the `cxcli stt` subcommand. You can read the documentation about this command [here](/cmd/cxcli_stt).
 
-The `cxcli stt` root command has the `recognize` command. You can find the usage of this command [here](/cmd/cxcli_stt_recognize).
+The `cxcli stt` command has a `recognize` subcommand. You can find the usage of this command [here](/cmd/cxcli_stt_recognize).
 
 ### Parameters
 
-These are the relevant parameters that you can use to interact with Google Cloud stt:
+These are the relevant parameters that you can use to interact with Google Cloud STT:
 
-1. `locale`: the locale accepts all the locales accepted by the Google `Cloud Speech-to-text API`. You can find all the locales available [here](https://cloud.google.com/speech-to-text/docs/speech-to-text-supported-languages)
+1. `locale`: this parameter accepts all of the locales that are available in the Google Cloud `Speech-to-text API`. You can find all the locales available [here](https://cloud.google.com/speech-to-text/docs/speech-to-text-supported-languages).
 
 ### Audio input file
 
-It is important to know that the input has to have this format:
+It is important to know that the input audio needs to be in the following format:
 
-1. A Sample Rate Hertz of 16000Hz
-2. The audio encoding has to be be Linear16. Linear16 is a 16-bit linear pulse-code modulation (PCM) encoding.
+1. A sample rate of 16000 Hertz
+2. The audio encoding has to be Linear16. Linear16 is a 16-bit linear pulse-code modulation (PCM) encoding.
 
-If you don't have a file with this format, you can create it by yourself using the `cxcli tts` command! All the information is located [here](/tts)
+If you don't have a file with this format, you can create it by yourself using the `cxcli tts` command! All of the relevant information is located [here](/tts).
 
 ## Example
 
-This a simple example of the `cxcli stt recognize` command:
+Here is a simple example of the `cxcli stt recognize` command:
 
 ```sh
 cxcli stt recognize hi.mp3  --locale en-US
 ```
 
-The command above will give you an audio file like this one:
+The above command will give you output similar to the following:
 
 ```sh
 $ cxcli stt recognize hi.mp3 --locale en-US --verbose
-INFO Duration time: 570 miliseconds               
-INFO Detections: 1                                
-INFO 1. Text detected: hi                         
-INFO 1. Confidence: 79.276474%                     
+INFO Duration time: 570 miliseconds
+INFO Detections: 1
+INFO 1. Text detected: hi
+INFO 1. Confidence: 79.276474%
 ```
 
-!!! info "are you running this command in a CICD pipeline?"
-    If this is the case, we recommend you to execute with the `--output-format` parameter set to `json`.
+!!! info "Are you running this command in a CI/CD pipeline?"
+    If this is the case, we recommend that you set the `--output-format` parameter to `json`.

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -2,28 +2,20 @@
 
 ## Getting support
 
-All users have access to a public Discord support for support and collaboration. Check the [links](/links) page.
+All users have access to a public Discord server for support and collaboration. Refer to the [links](/links) page for more information.
 
 ## Project not found
 
-Make sure that you have configured either the gcloud CLI or the authentication `json` file properly.
-
-You can find more information in the [Authentication](/overview/authentication) page.
+Make sure that you have configured either the `gcloud` CLI or the authentication `json` file properly. You can find more information on the [Authentication](/overview/authentication) page.
 
 ## You need to enable the Dialogflow API
 
-You have to enable the `Dialogflow API` on your GCP project if you want to interact with the `cxcli`. Make sure you have the permissions needed for the tool.
-
-You can find more information in the [Authentication](/overview/authentication) page.
+You need to enable the `Dialogflow API` in your Google Cloud project if you want to interact with `cxcli`. Make sure you have the permissions needed for the tool. You can find more information on the [Authentication](/overview/authentication) page.
 
 ## You need to enable the Cloud Speech-to-text API
 
-You have to enable the `Cloud Speech-to-text API` on your GCP project if you want to run the `cxcli stt` commands.
-
-You can find more information in the [Authentication](/overview/authentication) page.
+You need to enable the `Cloud Speech-to-text API` in your Google Cloud project if you want to run the `cxcli stt` commands. You can find more information on the [Authentication](/overview/authentication) page.
 
 ## You need to enable the Cloud Text-to-speech API
 
-You have to enable the `Cloud Text-to-speech API` on your GCP project if you want to run the `cxcli tts` commands
-
-You can find more information in the [Authentication](/overview/authentication) page.
+You need to enable the `Cloud Text-to-speech API` in your Google Cloud project if you want to run the `cxcli tts` commands. You can find more information on the [Authentication](/overview/authentication) page.

--- a/docs/docs/tts.md
+++ b/docs/docs/tts.md
@@ -1,49 +1,49 @@
 # Text-to-speech
 
 <p align="center">
-  <img alt="GCP TTS Logo" src="/images/tts.png" height="140" />
+  <img alt="Google Cloud TTS Logo" src="/images/tts.png" height="140" />
 </p>
 
 
-`cxcli` has some commands that allows you to interact with Google Cloud Text to Speech service using the `Cloud Text-to-Speech API`!
+The `cxcli` tool has various commands that allow you to interact with Google Cloud's Text to Speech service using the `Cloud Text-to-Speech API`!
 
 !!! info "Is this your first time using this feature?"
     Before you start using this functionality, please, read the [authentication](/overview/authentication) page.
 
 ## Usage
 
-You can find the text-to-speech commands usage down the `cxcli tts` command. You can read the documentation about this command [here](/cmd/cxcli_tts).
+You can find the text-to-speech functionality within the `cxcli tts` subcommand. You can read the documentation about this command [here](/cmd/cxcli_tts).
 
-The `cxcli tts` root command has the `synthesize` command. You can find the usage of this command [here](/cmd/cxcli_tts_synthesize).
+The `cxcli tts` command has a `synthesize` subcommand. You can find the usage of this command [here](/cmd/cxcli_tts_synthesize).
 
 ### Parameters
 
-These are the relevant parameters that you can use to interact with Google Cloud tts:
+These are the relevant parameters that you can use to interact with Google Cloud TTS:
 
-1. `locale`: the locale accepts all the locales accepted by the Google `Cloud Text-to-speech API`. You can find all the locales available [here](https://cloud.google.com/text-to-speech/docs/voices)
-2. `output-file`: mp3 file where we are going to write the synthesize text
+1. `locale`: this parameter accepts all of the locales that are available in the Google Cloud `Text-to-speech API`. You can find all the locales available [here](https://cloud.google.com/text-to-speech/docs/voices).
+2. `output-file`: MP3 audio file where we are going to output the synthesized text.
 
 ### Output
 
-It is important to know that the output will have this format:
+It is important to know that the output audio will have the following format:
 
-1. A Sample Rate Hertz of 16000Hz
+1. A sample rate of 16000 Hertz
 2. The audio encoding will be Linear16. Linear16 is a 16-bit linear pulse-code modulation (PCM) encoding.
 
 
 ## Example
 
-This a simple example of the `cxcli tts synthesize` command:
+Here is a simple example of the `cxcli tts synthesize` command:
 
 ```sh
 cxcli tts synthesize hi --locale en-US --output-file hi.mp3
 ```
 
-The command above will give you an audio file like this one:
+The above command will give you an audio file similar to the following:
 
 <audio controls>
   <source src="/static/hi.mp3" type="audio/mpeg">
 Your browser does not support the audio element.
 </audio>
 
-You can download the audio file [here](/static/hi.mp3)
+You can download the audio file [here](/static/hi.mp3).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -59,7 +59,7 @@ extra:
 
 plugins:
   - search
-  
+
 markdown_extensions:
   - attr_list
   - md_in_html
@@ -101,7 +101,7 @@ nav:
     - Reference:
       - Suites: nluprofiler/suites.md
       - Tests: nluprofiler/tests.md
-      - Examples: 
+      - Examples:
         - Simple: nluprofiler/examples/simple.md
         - Text input with entities: nluprofiler/examples/text.md
         - System entities detection: nluprofiler/examples/system.md
@@ -121,7 +121,7 @@ nav:
     - Delete: entitytypes/delete.md
   - Environments:
     - Introduction: environments/introduction.md
-    - CICD: environments/cicd.md
+    - CI/CD: environments/cicd.md
   - Text-to-speech: tts.md
   - Speech-to-text: stt.md
   - Command Line Usage:


### PR DESCRIPTION
Update all documentation pages to fix typos and improve readability/consistency throughout.

Summary of documentation changes:

* Reworked intro text in all sections for consistency
* Consistency in capitalization
* Github -> GitHub
* CICD -> CI/CD
* check the -> refer to the
* GCP -> Google Cloud
* Other various readability and consistency fixes

Please review and ensure that I have not changed the meaning of any substantial edits.

Also, thanks for all of the great documentation and explanations for this CLI tool!